### PR TITLE
Feat/flash backed configs and stabilize connection

### DIFF
--- a/examples/ublox.toit
+++ b/examples/ublox.toit
@@ -1,0 +1,50 @@
+// Copyright (C) 2023 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the EXAMPLES_LICENSE file.
+
+/**
+This example demonstrates how to use the Monarch service and connect it to a
+  cellular network.
+
+To run this example using Jaguar, you'll first need to install the
+  module service on the device.
+
+$ jag pkg install --project-root examples/
+$ jag container install ublox src/modules/ublox/sara_r5.toit
+$ jag run examples/ublox.toit
+*/
+
+import http
+import log
+import net.cellular
+
+main:
+  config ::= {
+    cellular.CONFIG_APN: "onomondo",
+
+    cellular.CONFIG_UART_TX: 16,
+    cellular.CONFIG_UART_RX: 17,
+    cellular.CONFIG-POWER: [21, 1],
+    cellular.CONFIG-RESET: [4, 1],
+
+    cellular.CONFIG_LOG_LEVEL: log.DEBUG-LEVEL,
+  }
+
+  logger := log.default.with_name "ublox"
+  logger.info "opening network"
+  network := cellular.open config
+
+  try:
+    client := http.Client network
+    host := "www.google.com"
+    response := client.get host "/"
+
+    bytes := 0
+    elapsed := Duration.of:
+      while data := response.body.read:
+        bytes += data.size
+
+    logger.info "http get" --tags={"host": host, "size": bytes, "elapsed": elapsed}
+
+  finally:
+    network.close

--- a/package.lock
+++ b/package.lock
@@ -1,9 +1,1 @@
 sdk: ^2.0.0-alpha.108
-prefixes:
-  http: pkg-http
-packages:
-  pkg-http:
-    url: github.com/toitlang/pkg-http
-    name: http
-    version: 2.3.4
-    hash: 39fe52083b4c745cc37420649a48277b45728fd2

--- a/package.lock
+++ b/package.lock
@@ -1,1 +1,9 @@
 sdk: ^2.0.0-alpha.108
+prefixes:
+  http: pkg-http
+packages:
+  pkg-http:
+    url: github.com/toitlang/pkg-http
+    name: http
+    version: 2.3.4
+    hash: 39fe52083b4c745cc37420649a48277b45728fd2

--- a/package.yaml
+++ b/package.yaml
@@ -2,3 +2,7 @@ name: cellular
 description: Cellular drivers for a selection of modems.
 environment:
   sdk: ^2.0.0-alpha.108
+dependencies:
+  http:
+    url: github.com/toitlang/pkg-http
+    version: ^2.3.4

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,3 @@ name: cellular
 description: Cellular drivers for a selection of modems.
 environment:
   sdk: ^2.0.0-alpha.108
-dependencies:
-  http:
-    url: github.com/toitlang/pkg-http
-    version: ^2.3.4

--- a/src/api/config.toit
+++ b/src/api/config.toit
@@ -14,8 +14,11 @@ interface CellularConfigService:
   set-apn apn/string
   static APN_INDEX ::= 0
 
+  set-operator operator/string
+  static OPERATOR_INDEX ::= 1
+
   set-pin-code pin/string
-  static PIN_INDEX ::= 1
+  static PIN_INDEX ::= 2
 
 class CellularConfigServiceClient extends services.ServiceClient implements CellularConfigService:
   static SELECTOR ::= CellularConfigService.SELECTOR
@@ -24,7 +27,10 @@ class CellularConfigServiceClient extends services.ServiceClient implements Cell
     super selector
 
   set-apn apn/string:
-    return invoke_ CellularConfigService.APN_INDEX null
+    return invoke_ CellularConfigService.APN_INDEX apn
+
+  set-operator operator/string:
+    return invoke_ CellularConfigService.OPERATOR_INDEX operator
 
   set-pin-code pin/string:
-    return invoke_ CellularConfigService.PIN_INDEX null
+    return invoke_ CellularConfigService.PIN_INDEX pin

--- a/src/api/config.toit
+++ b/src/api/config.toit
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import system.services
+import ..state show SignalQuality
+
+interface CellularConfigService:
+  static SELECTOR ::= services.ServiceSelector
+      --uuid="3f1b5a45-fe4b-4141-b087-66cc33993942"
+      --major=0
+      --minor=1
+
+  set-apn apn/string
+  static APN_INDEX ::= 0
+
+  set-pin-code pin/string
+  static PIN_INDEX ::= 1
+
+class CellularConfigServiceClient extends services.ServiceClient implements CellularConfigService:
+  static SELECTOR ::= CellularConfigService.SELECTOR
+  constructor selector/services.ServiceSelector=SELECTOR:
+    assert: selector.matches SELECTOR
+    super selector
+
+  set-apn apn/string:
+    return invoke_ CellularConfigService.APN_INDEX null
+
+  set-pin-code pin/string:
+    return invoke_ CellularConfigService.PIN_INDEX null

--- a/src/api/state.toit
+++ b/src/api/state.toit
@@ -11,7 +11,7 @@ interface CellularStateService:
       --major=0
       --minor=1
 
-  quality cache/bool -> SignalQuality?
+  quality -> SignalQuality?
   static QUALITY_INDEX ::= 0
 
   iccid -> string?
@@ -29,8 +29,8 @@ class CellularStateServiceClient extends services.ServiceClient implements Cellu
     assert: selector.matches SELECTOR
     super selector
 
-  quality cache/bool -> SignalQuality?:
-    result := invoke_ CellularStateService.QUALITY_INDEX cache
+  quality -> SignalQuality?:
+    result := invoke_ CellularStateService.QUALITY_INDEX null
     return result ? (SignalQuality --power=result[0] --quality=result[1]) : null
 
   iccid -> string?:

--- a/src/base/base.toit
+++ b/src/base/base.toit
@@ -178,7 +178,7 @@ abstract class CellularBase implements Cellular:
     return false
 
   is_ready_ session/at.Session:
-    response := session.action "" --timeout=(Duration --ms=250) --no-check
+    response := session.action "" --timeout=(Duration --s=2) --no-check
 
     if response == null:
       // By sleeping for even a little while here, we get a check for whether or
@@ -192,9 +192,9 @@ abstract class CellularBase implements Cellular:
     sleep --ms=100
 
     // Disable echo.
-    session.action "E0"
+    session.action "E0" --timeout=(Duration --s=5)
     // Verbose errors.
-    session.set "+CMEE" [2]
+    session.set "+CMEE" [2] --timeout=(Duration --s=5)
     // TODO(anders): This is where we want to use an optional PIN:
     //   session.set "+CPIN" ["1234"]
 

--- a/src/base/base.toit
+++ b/src/base/base.toit
@@ -209,6 +209,10 @@ abstract class CellularBase implements Cellular:
 
     return true
 
+  wait_for_sim:
+    at_.do: | session/at.Session |
+      wait_for_sim_ session
+
   wait_for_sim_ session/at.Session:
     // Wait up to 10 seconds for the SIM to be initialized.
     40.repeat:

--- a/src/base/cellular.toit
+++ b/src/base/cellular.toit
@@ -71,6 +71,8 @@ interface Cellular:
 
   wait_for_ready -> none
 
+  wait_for_sim -> none
+
   enable_radio -> none
 
   disable_radio -> none

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -534,13 +534,13 @@ class CellularStateServiceHandler_ implements ServiceHandler CellularStateServic
   constructor .provider:
 
   handle index/int arguments/any --gid/int --client/int -> any:
-    if index == CellularStateService.QUALITY_INDEX: return quality arguments
+    if index == CellularStateService.QUALITY_INDEX: return quality
     if index == CellularStateService.ICCID_INDEX: return iccid
     if index == CellularStateService.MODEL_INDEX: return model
     if index == CellularStateService.VERSION_INDEX: return version
     unreachable
 
-  quality cache/bool=true -> any:
+  quality -> any:
     result := null
     catch: result = provider.get_cached_signal_quality
     return result ? [ result.power, result.quality ] : null

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -221,12 +221,14 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
         with_timeout --ms=40_000: driver.wait_for_ready
 
       // Get iccid, model and version and cache them
-      catch: with-timeout --ms=5_000:
-        update_cached_iccid driver.iccid
-      catch: with-timeout --ms=5_000:
-        update_cached_model driver.model
-      catch: with-timeout --ms=5_000:
-        update_cached_version driver.version
+      // ICCID is ready from the SIM, so we need to
+      // wait for the SIM to be ready first.
+      catch:
+        with_timeout --ms=20_000:
+          driver.wait_for_sim
+          update_cached_model driver.model
+          update_cached_iccid driver.iccid
+          update_cached_version driver.version
 
       // The CFUN command (called in both driver.configure where
       // the modem is disable with CFUN=0 and then enabled again

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -218,7 +218,7 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
       if attempts_ > 0 and attempts_ % CELLULAR_FAILS_UNTIL_FACTORY_RESET == 0:
         logger.info "performing factory reset"
         driver.factory_reset
-        with_timeout --ms=20_000: driver.wait_for_ready
+        with_timeout --ms=40_000: driver.wait_for_ready
 
       // Get iccid, model and version and cache them
       catch: with-timeout --ms=5_000:

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -179,9 +179,7 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
         value := bucket_.get key
         // Only override valid values:
         if value is string and value.size > 0:
-          print "OVERRIDABLE_CONFIG_KEYS key=$key, value=$value"
           config_[key] = value
-    print "config_=$config_"
 
     return connect client
 
@@ -609,12 +607,10 @@ class CellularConfigServiceHandler_ implements ServiceHandler CellularConfigServ
     unreachable
 
   set-apn apn/string:
-    print "set-apn called with apn=$apn"
     catch: return provider.set-and-cache-apn apn
     return null
 
   set-operator operator/string:
-    print "set-operator called with operator=$operator"
     catch: return provider.set-and-cache-operator operator
     return null
 

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -223,10 +223,12 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
         with_timeout --ms=20_000: driver.wait_for_ready
 
       // Get iccid, model and version and cache them
-      /* catch: with-timeout --ms=5_000:
+      catch: with-timeout --ms=5_000:
         update_cached_iccid driver.iccid
+      catch: with-timeout --ms=5_000:
         update_cached_model driver.model
-        update_cached_version driver.version */
+      catch: with-timeout --ms=5_000:
+        update_cached_version driver.version
 
       // The CFUN command (called in both driver.configure where
       // the modem is disable with CFUN=0 and then enabled again

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -106,7 +106,6 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
   scores_/OperatorScores := ?
 
   constructor name/string --major/int --minor/int --patch/int=0:
-    print "CellularServiceProvider constructor called! id=$(random 1000)"
     attempts/int? := null
     scores/Map? := null
 
@@ -208,8 +207,6 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
     configured_operator := config_.get CONFIG_OPERATOR_KEY --if-absent=:""
     pin_code := config_.get CONFIG_PIN_CODE_KEY --if_absent=:""
 
-    print "apn=$apn bands=$bands rats=$rats configured_operator=$configured_operator pin_code=$pin_code"
-
     try:
       // Perform factory reset, if we have tried to connect without
       // success more than 31 times (we offset it by 1 to ensure that
@@ -293,12 +290,11 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
             if scores_.score_for_last_operator < OPERATOR_SCORE_THRESHOLD or should_scan:
               operator_ = scores_.get_best_operator
               if operator_:
-                print "Using operator $operator_.op with score $(%.2f scores_.score_for_last_operator)%"
+                logger.debug "using operator $operator_.op with score $(%.2f scores_.score_for_last_operator)%"
 
       // Connects can take up to 3 minutes on u-blox SARA
       with_timeout --ms=180_000:
         logger.info "connecting"
-        print "[CellularDebug] Connecting with operator_=$operator_ and apn=$apn"
         driver.connect --operator=operator_
           
       update_attempts_ 0  // Success. Reset the attempts.

--- a/src/config.toit
+++ b/src/config.toit
@@ -1,0 +1,18 @@
+// Copyright (C) 2023 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import .api.config
+
+service_/CellularConfigServiceClient? ::= (CellularConfigServiceClient).open
+    --if_absent=: null
+
+set-apn apn/string:
+  service := service_
+  if not service: throw "cellular unavailable"
+  return service.set-apn apn
+
+set-pin-code pin/string:
+  service := service_
+  if not service: throw "cellular unavailable"
+  return service.set-pin-code pin

--- a/src/config.toit
+++ b/src/config.toit
@@ -12,6 +12,11 @@ set-apn apn/string:
   if not service: throw "cellular unavailable"
   return service.set-apn apn
 
+set-operator operator/string:
+  service := service_
+  if not service: throw "cellular unavailable"
+  return service.set-operator operator
+
 set-pin-code pin/string:
   service := service_
   if not service: throw "cellular unavailable"

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -33,6 +33,7 @@ class SaraR5Service extends CellularServiceProvider:
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?:
+    print "SaraR5Service.create_driver id=$(random 1000)"
     return SaraR5 port logger
         --rx=rx
         --tx=tx

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -149,6 +149,7 @@ class SaraR5 extends UBloxCellular:
     // We do this by setting PWR_ON high (the line is inverted
     // on most boards), then waiting for 1.5s
     critical_do --no-respect_deadline:
+      logger.debug "Performing power_on sequence for Sara-R5"
       pwr_on.set 1
       sleep --ms=1500
       pwr_on.set 0

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -33,7 +33,6 @@ class SaraR5Service extends CellularServiceProvider:
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?:
-    print "SaraR5Service.create_driver id=$(random 1000)"
     return SaraR5 port logger
         --rx=rx
         --tx=tx
@@ -149,7 +148,7 @@ class SaraR5 extends UBloxCellular:
     // We do this by setting PWR_ON high (the line is inverted
     // on most boards), then waiting for 1.5s
     critical_do --no-respect_deadline:
-      logger.debug "Performing power_on sequence for Sara-R5"
+      logger.debug "performing power_on sequence for Sara-R5"
       pwr_on.set 1
       sleep --ms=1500
       pwr_on.set 0

--- a/src/modules/ublox/ublox.toit
+++ b/src/modules/ublox/ublox.toit
@@ -128,7 +128,11 @@ class TcpSocket extends Socket_ implements tcp.Socket:
     cellular_.at_.do: | session/at.Session |
       try:
         session.set "+USOWR" [get_id_, data.size] --data=data
-      finally: | is_exception _ |
+      finally: | is_exception e |
+        //TODO: Handle this better to recover in current state wihout starting completely over.
+        // May poll last socket error with: +USOCTL=1 or listen for +UUSOCL URC code
+        print "EXCEPTION: $is_exception - $e"
+        
         // If we get an exception while writing, we risk leaving the
         // modem in an awful state. Close the session to force us to
         // start over.

--- a/src/modules/ublox/ublox.toit
+++ b/src/modules/ublox/ublox.toit
@@ -136,6 +136,8 @@ class TcpSocket extends Socket_ implements tcp.Socket:
         // modem in an awful state. Close the session to force us to
         // start over.
         if is_exception:
+          print "USOWR EXCEPTION: $e"
+          sleep --ms=5000 // TODO: Sleep some time to see if the URC code comes. Remove this test at some point
           if provider_:
             provider_.disconnect
           else:

--- a/src/modules/ublox/ublox.toit
+++ b/src/modules/ublox/ublox.toit
@@ -131,7 +131,6 @@ class TcpSocket extends Socket_ implements tcp.Socket:
       finally: | is_exception e |
         //TODO: Handle this better to recover in current state wihout starting completely over.
         // May poll last socket error with: +USOCTL=1 or listen for +UUSOCL URC code
-        print "EXCEPTION: $is_exception - $e"
         
         // If we get an exception while writing, we risk leaving the
         // modem in an awful state. Close the session to force us to

--- a/src/modules/ublox/ublox.toit
+++ b/src/modules/ublox/ublox.toit
@@ -406,10 +406,10 @@ abstract class UBloxCellular extends CellularBase:
         // If the chip was recently rebooted, wait for it to be responsive before
         // communicating with it again.
         attempts := 0
-        while not select_baud_ session:
-          if ++attempts > 5: return
-        // Send the power-off command.
-        session.send CPWROFF
+        catch --trace: with-timeout --ms=20_000:
+          while true:
+            session.send CPWROFF
+            return
     finally:
       at_session_.close
       uart_.close

--- a/src/modules/ublox/ublox.toit
+++ b/src/modules/ublox/ublox.toit
@@ -638,7 +638,9 @@ abstract class UBloxCellular extends CellularBase:
     // Set the baud rate to the requested one.
     session.set "+IPR" [baud_rate]
     uart_.baud_rate = baud_rate
-    sleep --ms=100
+
+    // Wait for at least 100ms before issuing a new command.
+    sleep --ms=150
 
   open_network --provider/ProxyingNetworkServiceProvider?=null -> net.Interface:
     return Interface_ network_name this provider

--- a/src/state.toit
+++ b/src/state.toit
@@ -12,10 +12,10 @@ class SignalQuality:
   quality/float?
   constructor --.power --.quality:
 
-quality --cache/bool=true -> SignalQuality?:
+quality -> SignalQuality?:
   service := service_
   if not service: throw "cellular unavailable"
-  return service.quality cache
+  return service.quality
 
 iccid -> string?:
   service := service_


### PR DESCRIPTION
**_New feature:_**
- Parse selected configs from flash:
  - ICCID
  - APN
  - PIN-CODE

**_Multiple robustness upgrades:_**
- Wait for URC returned by USPDA
- Make startup sequence more robust by not changing baud and run power-on sequence on every attempt
- Only wait for network register event (+CEREG) URC if it's not already registered
- Wait for SIM ready before polling ICCID
- Call AT+CWROFF directly (but retry multiple times) instead of running baud rate response tests before close